### PR TITLE
Include more categories, to find details for more listed games

### DIFF
--- a/src/games/games.service.ts
+++ b/src/games/games.service.ts
@@ -16,6 +16,24 @@ type GenresMap = { [genreId: string]: IGDB_Genre['name'] };
 type CoversMap = { [gameId in IGDB_Game['id']]: IGDB_Cover };
 type GamesMap = { [search: string]: IGDB_Game[] };
 
+const GAME_CATEGORIES = {
+  main_game: 0,
+  dlc_addon: 1,
+  expansion: 2,
+  bundle: 3,
+  standalone_expansion: 4,
+  mod: 5,
+  episode: 6,
+  season: 7,
+  remake: 8,
+  remaster: 9,
+  expanded_game: 10,
+  port: 11,
+  fork: 12,
+  pack: 13,
+  update: 14,
+};
+
 const sortGames = sortWith<Game>([
   ascend(prop('name')),
   descend(propOr(0, 'releaseYear')),
@@ -126,11 +144,10 @@ export class GamesService {
       console.info(`🗄  Serving "${search}" from cache.`);
       return Promise.resolve(this.gameCache[search]);
     }
-    const MAIN_GAME_CATEGORY = 0;
     const searchQuery = `
       ${search ? `search "${search}";` : ''}
       fields *;
-      where category=${MAIN_GAME_CATEGORY};
+      where category != ${GAME_CATEGORIES.bundle};
     `;
     let games: IGDB_Game[] = [];
     try {


### PR DESCRIPTION
Games like "TowerFall Ascension" or "Day of Defeat: Source" are not listed as [main_game](https://api-docs.igdb.com/#game-enums), so this allows more categories in our IGDB query/filter string.